### PR TITLE
3 new post is not applyed

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -34,6 +34,8 @@ github_username:  jekyll
 
 permalink: /:slug
 
+timezone: ROK
+
 # favicon: "logo.png" # name+extension of favicon (which must be put on the root folder)
 # goat_counter: "yoursitename" # put your GoatCounter name if you want to use GoatCounter analytics
 

--- a/_posts/2024-08-28-my-first_post.md
+++ b/_posts/2024-08-28-my-first_post.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: My First Post
+title: "My First Post"
 category: 
 ---
 

--- a/_posts/2024-08-28-my-first_post.md
+++ b/_posts/2024-08-28-my-first_post.md
@@ -1,7 +1,6 @@
 ---
 layout: post
 title: "My First Post"
-category: 
 ---
 
 # This is My First Post


### PR DESCRIPTION
jekyll의 timezone은 기본적으로 UTC로 되어있음.
post의 date가 ROK 기준이고 ROK와 UTC가 서로 날짜가 다른 상황이라면 ROK를 사용하는 local환경에서는 post가 보이지만 아직 post 날짜보다 하루 전인 UTC를 사용하는 github page에서는 post가 보이지 않음.
`_config.yml`에 `timezone: ROK`을 추가하여 해결함.

close #3